### PR TITLE
fix: rollup build ts absolute import path

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-scss', '@storybook/addon-mdx-gfm'],
@@ -9,4 +11,11 @@ module.exports = {
     autodocs: true
   },
   staticDirs: ['../src/assets'],
+  webpackFinal: async (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'src': path.resolve(__dirname, '../src/'),
+    };
+    return config;
+  },
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,13 @@ export default [
   {
     input: 'dist/esm/index.d.ts',
     output: [{ file: 'dist/index.d.ts', format: 'esm' }],
-    plugins: [dts()],
+    plugins: [
+      dts({
+        compilerOptions: {
+          baseUrl: './',
+        },
+      }),
+    ],
     external: [/\.(css|scss)$/],
   },
 ];

--- a/src/components/Autocomplete/index.ts
+++ b/src/components/Autocomplete/index.ts
@@ -1,1 +1,1 @@
-export { Autocomplete } from './AutoComplete';
+export { Autocomplete } from './Autocomplete';

--- a/src/components/Autocomplete/index.ts
+++ b/src/components/Autocomplete/index.ts
@@ -1,1 +1,1 @@
-export { Autocomplete } from './Autocomplete';
+export { Autocomplete } from './AutoComplete';

--- a/src/components/Checkbox/MuiCheckbox.stories.tsx
+++ b/src/components/Checkbox/MuiCheckbox.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import { MuiCheckbox as Checkbox } from './MuiCheckbox';
+
+export default {
+  title: 'MUI/Components/Checkbox',
+  component: Checkbox,
+};
+
+const Template: StoryFn<typeof Checkbox> = (args) => <Checkbox {...args} />;
+
+export const Small = Template.bind({});
+Small.args = {
+  size: 'small',
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  size: 'medium',
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  size: 'large',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  color: 'error',
+  defaultChecked: true,
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  color: 'warning',
+  defaultChecked: true,
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  disabled: true,
+  defaultChecked: true,
+};
+
+export const accent = Template.bind({});
+accent.args = {
+  color: 'accent',
+  defaultChecked: true,
+};
+
+export const info = Template.bind({});
+info.args = {
+  color: 'info',
+  defaultChecked: true,
+};

--- a/src/components/Checkbox/MuiCheckbox.tsx
+++ b/src/components/Checkbox/MuiCheckbox.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
-
-interface CustomCheckboxPropsSizeOverrides {
-  small: true;
-  medium: true;
-  large: true;
-}
-
-interface CustomCheckboxPropsColorOverrides {
-  accent: true;
-  grey: true;
-}
+import type { CustomColorOverrides } from 'src/types/color.type';
+import type { CustomCheckboxPropsSizeOverrides } from 'src/types/size.type';
 
 declare module '@mui/material/Checkbox' {
   interface CheckboxPropsSizeOverrides extends CustomCheckboxPropsSizeOverrides {}
-  interface CheckboxPropsColorOverrides extends CustomCheckboxPropsColorOverrides {}
+  interface CheckboxPropsColorOverrides extends CustomColorOverrides {}
 }
 
 export interface MuiCheckboxProps extends CheckboxProps {}

--- a/src/components/Checkbox/MuiCheckbox.tsx
+++ b/src/components/Checkbox/MuiCheckbox.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
+
+interface CustomCheckboxPropsSizeOverrides {
+  small: true;
+  medium: true;
+  large: true;
+}
+
+interface CustomCheckboxPropsColorOverrides {
+  accent: true;
+  grey: true;
+}
+
+declare module '@mui/material/Checkbox' {
+  interface CheckboxPropsSizeOverrides extends CustomCheckboxPropsSizeOverrides {}
+  interface CheckboxPropsColorOverrides extends CustomCheckboxPropsColorOverrides {}
+}
+
+export interface MuiCheckboxProps extends CheckboxProps {}
+
+const sizeMapper = {
+  small: 14,
+  medium: 16,
+  large: 24,
+};
+
+const Svg: React.FC = ({ children }) => (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 14 14"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    preserveAspectRatio="xMidYMid meet"
+  >
+    {children}
+  </svg>
+);
+
+const UncheckedIcon = (
+  <Svg>
+    <rect x="0.5" y="0.5" width="13" height="13" rx="2.5" stroke="black" strokeOpacity="0.13" />
+  </Svg>
+);
+
+const CheckedIcon = (
+  <Svg>
+    <rect width="14" height="14" rx="3" fill="currentColor" />
+    <path
+      d="M5.24994 9.45L2.79994 7L1.98328 7.81666L5.24994 11.0833L12.2499 4.08333L11.4333 3.26666L5.24994 9.45Z"
+      fill="white"
+    />
+  </Svg>
+);
+
+const MuiCheckbox = ({ size = 'medium', ...props }: MuiCheckboxProps) => {
+  const svgSize = sizeMapper[size] ?? sizeMapper.medium;
+  return (
+    <Checkbox
+      size={size}
+      sx={{
+        padding: 0,
+        width: svgSize,
+      }}
+      {...props}
+      disableRipple
+      icon={UncheckedIcon}
+      checkedIcon={CheckedIcon}
+    />
+  );
+};
+
+export { MuiCheckbox };

--- a/src/components/Checkbox/index.ts
+++ b/src/components/Checkbox/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Checkbox';
+export * from './MuiCheckbox';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,7 @@
 export { default as Alert } from './Alert';
 export * from './Autocomplete';
 export * from './Button';
-export { default as Checkbox } from './Checkbox';
+export { default as Checkbox, MuiCheckbox } from './Checkbox';
 export { default as CheckboxGroup } from './CheckboxGroup';
 export { default as Chip } from './Chip';
 export { default as ItemCard } from './ItemCard';

--- a/src/types/color.type.ts
+++ b/src/types/color.type.ts
@@ -1,0 +1,1 @@
+export type CustomColors = "primary" | "secondary" | "error" | "info" | "success" | "warning" | 'grey' | 'accent'

--- a/src/types/color.type.ts
+++ b/src/types/color.type.ts
@@ -1,1 +1,6 @@
-export type CustomColors = "primary" | "secondary" | "error" | "info" | "success" | "warning" | 'grey' | 'accent'
+export type CustomColors = 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' | 'grey' | 'accent';
+
+export interface CustomColorOverrides {
+  grey: true;
+  accent: true;
+}

--- a/src/types/size.type.ts
+++ b/src/types/size.type.ts
@@ -1,1 +1,7 @@
 export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface CustomCheckboxPropsSizeOverrides {
+  small: true;
+  medium: true;
+  large: true;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./",
     "target": "es5",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -16,9 +16,6 @@
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true,
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
-    "paths": {
-      "@assets/*": ["src/assets/*"]
-    }
   },
   "include": ["types/modules.d.ts", "types/svg.d.ts", "src/"],
   "exclude": ["node_modules/"]


### PR DESCRIPTION
Absolute imports set in the `tsconfig` configuration does not work in storybook and types being bundles by rollup
This fixes that for absolute imports

Before bundling
<img width="608" alt="image" src="https://github.com/timberhubcom/timberhub-component-library/assets/40042573/6861ff27-b907-4604-85ea-eb11b37b7b0c">


After bundling
<img width="702" alt="image" src="https://github.com/timberhubcom/timberhub-component-library/assets/40042573/990248bb-3e89-4627-a4c0-1ae782c5bf80">
