### PR TITLE
fix: rollup build ts absolute import path

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/preset-scss', '@storybook/addon-mdx-gfm'],
@@ -9,4 +11,11 @@ module.exports = {
     autodocs: true
   },
   staticDirs: ['../src/assets'],
+  webpackFinal: async (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'src': path.resolve(__dirname, '../src/'),
+    };
+    return config;
+  },
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,13 @@ export default [
   {
     input: 'dist/esm/index.d.ts',
     output: [{ file: 'dist/index.d.ts', format: 'esm' }],
-    plugins: [dts()],
+    plugins: [
+      dts({
+        compilerOptions: {
+          baseUrl: './',
+        },
+      }),
+    ],
     external: [/\.(css|scss)$/],
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./",
     "target": "es5",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -16,9 +16,6 @@
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true,
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
-    "paths": {
-      "@assets/*": ["src/assets/*"]
-    }
   },
   "include": ["types/modules.d.ts", "types/svg.d.ts", "src/"],
   "exclude": ["node_modules/"]


### PR DESCRIPTION
Reverts timberhubcom/timberhub-component-library#42