### PR TITLE
TH-74 feat: form control label

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,4 +18,18 @@ module.exports = {
     };
     return config;
   },
+   typescript: {
+    check: false,
+    checkOptions: {},
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: (prop) => {
+        return prop.parent
+          ? /@mui/.test(prop.parent.fileName) ||
+            !/node_modules/.test(prop.parent.fileName)
+          : true;
+      },
+    },
+  },
 };

--- a/src/components/Checkbox/MuiCheckbox.tsx
+++ b/src/components/Checkbox/MuiCheckbox.tsx
@@ -45,14 +45,16 @@ const CheckedIcon = (
   </Svg>
 );
 
-const MuiCheckbox = ({ size = 'medium', ...props }: MuiCheckboxProps) => {
+const MuiCheckbox = ({ size = 'medium', sx, ...props }: MuiCheckboxProps) => {
   const svgSize = sizeMapper[size] ?? sizeMapper.medium;
   return (
     <Checkbox
       size={size}
       sx={{
         padding: 0,
+        marginInline: '9px',
         width: svgSize,
+        ...sx,
       }}
       {...props}
       disableRipple

--- a/src/components/Form/FormControlLabel.stories.tsx
+++ b/src/components/Form/FormControlLabel.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import { FormControlLabel, FormControlLabelProps } from './FormControlLabel';
+import { MuiCheckbox } from '../Checkbox';
+import { Box } from '@mui/material';
+
+export default {
+  title: 'MUI/Components/FormControlLabel',
+  component: FormControlLabel,
+};
+
+const Template: StoryFn<FormControlLabelProps> = (args) => {
+  const [checked, setChecked] = React.useState(false);
+  return (
+    <Box sx={{ width: '300px' }}>
+      <FormControlLabel
+        {...args}
+        control={
+          <MuiCheckbox
+            checked={checked}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => setChecked(event.target.checked)}
+            name="form"
+          />
+        }
+      />
+    </Box>
+  );
+};
+
+export const Base = Template.bind({});
+Base.args = {
+  label: 'This product needs to be ISPM5',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  label: 'This product needs to be ISPM5',
+  required: true,
+};
+
+export const LabelStart = Template.bind({});
+LabelStart.args = {
+  label: 'This product needs to be ISPM5',
+  labelPlacement: 'start',
+};
+
+export const LabelTop = Template.bind({});
+LabelTop.args = {
+  label: 'This product needs to be ISPM5',
+  labelPlacement: 'top',
+};
+
+export const LabelBottom = Template.bind({});
+LabelBottom.args = {
+  label: 'This product needs to be ISPM5',
+  labelPlacement: 'bottom',
+};

--- a/src/components/Form/FormControlLabel.tsx
+++ b/src/components/Form/FormControlLabel.tsx
@@ -1,0 +1,12 @@
+import MuiFormControlLabel, { FormControlLabelProps as MuiFormControlLabelProps } from '@mui/material/FormControlLabel';
+import { TypographyVariantOverrides } from '../../types/typography.types';
+
+declare module '@mui/material/Typography' {
+  export interface TypographyPropsVariantOverrides extends TypographyVariantOverrides {}
+}
+
+export interface FormControlLabelProps extends MuiFormControlLabelProps {}
+
+const FormControlLabel = MuiFormControlLabel as React.FC<FormControlLabelProps>;
+
+export { FormControlLabel };

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,1 +1,6 @@
 export { FormControlLabel } from './FormControlLabel'
+
+export {default as FormControl} from '@mui/material/FormControl'
+export {default as FormGroup} from '@mui/material/FormGroup'
+export {default as FormHelperText} from '@mui/material/FormHelperText'
+export {default as FormLabel} from '@mui/material/FormLabel'

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,0 +1,1 @@
+export { FormControlLabel } from './FormControlLabel'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './Button';
 export { default as Checkbox, MuiCheckbox } from './Checkbox';
 export { default as CheckboxGroup } from './CheckboxGroup';
 export { default as Chip } from './Chip';
+export * from './Form';
 export { default as ItemCard } from './ItemCard';
 export { Link } from './Link';
 export { default as Pagination } from './Pagination';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './color.type'
+export * from './size.type'
+export * from './typography.types'


### PR DESCRIPTION
This is the form control label component for radio, switch & checkboxes

The checkboxes for example are just standalone components, but this gives it superpowers and add labels and other form control attributes such as required field, etc.

<img width="702" alt="image" src="https://github.com/timberhubcom/timberhub-component-library/assets/40042573/09de3b79-24b5-4017-aab9-bd02c6458a35">
