### PR TITLE
Fix/data-item-multiline

### DIFF
--- a/src/components/DataItem/DataItem.tsx
+++ b/src/components/DataItem/DataItem.tsx
@@ -5,7 +5,6 @@ import { cx, css } from '@emotion/css';
 import { tokens } from '../../theme/tokens';
 
 import { Typography } from '../Typography';
-import styled from '@emotion/styled';
 
 export type DataItemsProps = {
   icon: string;
@@ -14,17 +13,20 @@ export type DataItemsProps = {
   className?: string;
 };
 
-const DataItemWrapper = styled(Paper)`
-  display: grid;
-  grid-template-columns: auto 1fr;
-`;
-
 export const DataItem = React.forwardRef<HTMLDivElement, DataItemsProps>(function DataItem(
   { icon, title, description, className, ...props },
   ref,
 ) {
   return (
-    <DataItemWrapper variant="outlined" className={cx(className)} ref={ref}>
+    <Paper
+      variant="outlined"
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+      }}
+      className={cx(className)}
+      ref={ref}
+    >
       <Box display="flex">
         <img src={icon} alt="" className={styles.icon(tokens.colors.shade)} />
       </Box>
@@ -32,7 +34,7 @@ export const DataItem = React.forwardRef<HTMLDivElement, DataItemsProps>(functio
         <Typography variant="headline_ss_xxs">{title}</Typography>
         <Typography variant="body_s">{description}</Typography>
       </Box>
-    </DataItemWrapper>
+    </Paper>
   );
 });
 

--- a/src/components/DataItem/DataItem.tsx
+++ b/src/components/DataItem/DataItem.tsx
@@ -24,12 +24,10 @@ export const DataItem = React.forwardRef<HTMLDivElement, DataItemsProps>(functio
         display: 'grid',
         gridTemplateColumns: 'auto 1fr',
       }}
-      className={cx(className)}
+      className={className}
       ref={ref}
     >
-      <Box display="flex">
-        <img src={icon} alt="" className={styles.icon(tokens.colors.shade)} />
-      </Box>
+      <img src={icon} alt="" className={styles.icon(tokens.colors.shade)} />
       <Box sx={{ flex: '1 0 auto', p: 2, pb: 2.25 }}>
         <Typography variant="headline_ss_xxs">{title}</Typography>
         <Typography variant="body_s">{description}</Typography>
@@ -43,6 +41,7 @@ const styles = {
     background-color: ${bgColor};
     width: 74px;
     min-height: 79px;
+    height: 100%;
   `,
 };
 

--- a/src/components/DataItem/DataItem.tsx
+++ b/src/components/DataItem/DataItem.tsx
@@ -5,6 +5,7 @@ import { cx, css } from '@emotion/css';
 import { tokens } from '../../theme/tokens';
 
 import { Typography } from '../Typography';
+import styled from '@emotion/styled';
 
 export type DataItemsProps = {
   icon: string;
@@ -13,18 +14,25 @@ export type DataItemsProps = {
   className?: string;
 };
 
+const DataItemWrapper = styled(Paper)`
+  display: grid;
+  grid-template-columns: auto 1fr;
+`;
+
 export const DataItem = React.forwardRef<HTMLDivElement, DataItemsProps>(function DataItem(
   { icon, title, description, className, ...props },
   ref,
 ) {
   return (
-    <Paper variant="outlined" sx={{ display: 'flex' }} className={cx(className)} ref={ref}>
-      <img src={icon} alt="" className={styles.icon(tokens.colors.shade)} />
+    <DataItemWrapper variant="outlined" className={cx(className)} ref={ref}>
+      <Box display="flex">
+        <img src={icon} alt="" className={styles.icon(tokens.colors.shade)} />
+      </Box>
       <Box sx={{ flex: '1 0 auto', p: 2, pb: 2.25 }}>
         <Typography variant="headline_ss_xxs">{title}</Typography>
         <Typography variant="body_s">{description}</Typography>
       </Box>
-    </Paper>
+    </DataItemWrapper>
   );
 });
 
@@ -32,7 +40,7 @@ const styles = {
   icon: (bgColor: string) => css`
     background-color: ${bgColor};
     width: 74px;
-    height: 79px;
+    min-height: 79px;
   `,
 };
 


### PR DESCRIPTION
Fixing the style for the dataitem/dataitemslist component when title & description goes beyond 1 line

Before
![image](https://github.com/timberhubcom/timberhub-component-library/assets/40042573/f0207e91-1a75-4079-9b19-9c68c592398b)

After
![image](https://github.com/timberhubcom/timberhub-component-library/assets/40042573/3c0855f0-453a-4dd8-bb3f-1a07d85c7224)
