### PR TITLE
TH-129 use different key for loader header and header

### DIFF
--- a/src/components/NewTable/NewTable.tsx
+++ b/src/components/NewTable/NewTable.tsx
@@ -61,7 +61,7 @@ export const NewTable = <TData extends object>({
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <TableHead
-                  key={header.id}
+                  key={crypto.randomUUID()}
                   className={styles.head(header.getSize(), header.column.columnDef.enablePinning)}
                 >
                   {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}


### PR DESCRIPTION
Used different keys for the headers.

Due to the translations being swapped in the DOM, react didn't re-render the table header because they had the same key causing a Node mismatch for translations.